### PR TITLE
Add Kaggle training workflow and DBSCAN baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+results/
+__pycache__/
+*.pyc

--- a/Kaggle_training_steps.txt
+++ b/Kaggle_training_steps.txt
@@ -1,0 +1,105 @@
+Kaggle Training Playbook
+========================
+
+The checklist below enumerates every step required to train the DEC, IDEC, and
+DBSCAN models from this repository inside a Kaggle Notebook environment.
+
+0. Prerequisites
+----------------
+- Ensure you have an active Kaggle account and are signed in.
+- Export this repository as a `.zip` file or push it to a GitHub repository that
+  Kaggle can access. The notebook expects the `src/` and `notebooks/` folders to
+  be present.
+- Collect the feature matrix (`x.npy`) and, if available, the label array
+  (`y.npy`). If your data is in another format, convert it to NumPy arrays prior
+  to uploading.
+
+1. Stage the project on Kaggle
+------------------------------
+1.1. Navigate to **Datasets ➜ New Dataset** on Kaggle.
+1.2. Upload the repository archive (`CMU-vPCF-Project.zip`) and any required
+     `.npy` files into a new private dataset (e.g., `vpcf-project-data`).
+1.3. After the upload completes, publish the dataset. Note the generated slug –
+     Kaggle will expose the files at `/kaggle/input/vpcf-project-data/` inside
+     notebook sessions.
+
+2. Launch a Kaggle Notebook
+---------------------------
+2.1. Go to **Code ➜ Notebooks ➜ New Notebook**.
+2.2. In the right-hand *Settings* pane:
+     - Under **Data**, click *Add data* and attach the dataset you created in
+       Step 1 (e.g., `vpcf-project-data`).
+     - (Optional) Enable a GPU or TPU accelerator under **Accelerator** if you
+       plan to run long DEC/IDEC training sessions.
+     - (Optional) Change the **Internet** toggle to *Off* to comply with
+       competition rules if necessary; the notebook only needs local files.
+2.3. Choose *Notebook* (not Script) as the editor type to retain the interactive
+     interface.
+
+3. Load the project notebook
+----------------------------
+3.1. Inside the Kaggle editor, expand the file browser on the left.
+3.2. Open the dataset you attached and locate `CMU-vPCF-Project/notebooks/`.
+3.3. Double-click `Kaggle_Training.ipynb` to open it in the main editor pane.
+3.4. Verify that the first markdown cell renders correctly; if it does not,
+     click **File ➜ Save Version** to ensure Kaggle loads the latest files from
+     the dataset.
+
+4. Execute the workflow cells
+-----------------------------
+4.1. **Section 1 – Environment setup**
+     - Run the first code cell. It installs dependencies listed in
+       `requirements.txt` and appends `src/` to `sys.path` so the DEC/IDEC/DBSCAN
+       modules are importable.
+4.2. **Section 2 – Configure data and output directories**
+     - Edit the `data_path` assignment to reference your uploaded features. For
+       example: `Path('/kaggle/input/vpcf-project-data/x.npy')`.
+     - If you uploaded labels, set `labels_path` accordingly; otherwise keep it
+       as `None`.
+     - Adjust `results_root` if you want to save artifacts somewhere other than
+       `/kaggle/working/results`.
+     - Run the cell to create the results directory.
+4.3. **Section 3 – Load the dataset**
+     - Execute the cell. It validates the paths, loads the arrays, and reports
+       their shapes. If it raises `FileNotFoundError`, revisit Step 4.2.
+4.4. **Section 4 – Train DEC**
+     - Review the architecture dimensions and hyperparameters. Modify `dims`,
+       `n_clusters`, `epochs`, `maxiter`, or `batch_size` to suit your dataset
+       size.
+     - Run the cell. It saves pretraining weights to
+       `/kaggle/working/results/dec/` and logs training progress in
+       `dec_log.csv`.
+4.5. **Section 5 – Train IDEC**
+     - Execute the cell. If the autoencoder weights from Step 4 exist, the
+       notebook reuses them. IDEC outputs checkpoints and logs to
+       `/kaggle/working/results/idec/`.
+4.6. **Section 6 – Run DBSCAN baseline**
+     - Adjust `eps` and `min_samples` if needed (smaller `eps` discovers finer
+       clusters; larger `min_samples` suppresses noise).
+     - Run the cell to produce DBSCAN cluster assignments. When labels are
+       supplied, the cell prints accuracy, NMI, and ARI scores with noise points
+       excluded from the evaluation.
+4.7. **Section 7 – Inspect generated artifacts**
+     - Execute the final cell to list every file saved under the results
+       directory. This helps confirm that weights and logs are ready for
+       download.
+
+5. Save and export results
+--------------------------
+5.1. Click **+ Add output** next to any files you want to export (e.g.,
+     `DEC_model_final.weights.h5`, `idec_log.csv`).
+5.2. Use **File ➜ Save Version** to create a checkpoint of the notebook run.
+5.3. After the notebook finishes, download artifacts via the right-hand *Output*
+     panel or by promoting them to a Kaggle dataset.
+
+6. Optional follow-up analyses
+------------------------------
+- Upload the results folder back to this repository for version control.
+- Compare DEC, IDEC, and DBSCAN performance using the metrics printed in the
+  notebook and the CSV logs stored under `/kaggle/working/results/`.
+- Iterate on hyperparameters directly in the notebook; Kaggle sessions persist
+  for the duration of the run, so you can repeatedly edit and re-execute cells.
+
+Completion of the above steps guarantees that the Kaggle environment is fully
+prepared and that all three clustering models are executed with reproducible
+artifacts.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ framework for using deep embedded clustering to cluster vector pair correlation 
 
 ## Project Structure
 - `data/`: VPCF image data
-- `notebooks/`: Jupyter notebook that walks through process of loading data, training the model, and evaluating the results
-- `src/`: source code for the IDEC and DEC algorithms
+- `notebooks/`: interactive notebooks for experimentation. `VPCF_Clustering.ipynb` demonstrates the local workflow, while `Kaggle_Training.ipynb` is pre-configured for running on Kaggle's managed hardware.
+- `src/`: source code for the IDEC, DEC, and DBSCAN clustering pipelines
 - `requirements.txt`: required Python libraries
+
+## Remote training on Kaggle
+
+For detailed, step-by-step instructions on executing the training pipeline in a
+Kaggle Notebook (including DEC, IDEC, and the DBSCAN baseline), see
+`Kaggle_training_steps.txt`. The accompanying `notebooks/Kaggle_Training.ipynb`
+automates the dependency setup, dataset loading, and model execution within the
+Kaggle environment.

--- a/notebooks/Kaggle_Training.ipynb
+++ b/notebooks/Kaggle_Training.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8c98dcda",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# Kaggle Cloud Training Workflow\n",
+    "\n",
+    "This notebook orchestrates remote training on Kaggle's GPU or TPU runtimes. It\n",
+    "assumes that the repository contents (including the `src/` modules) are available\n",
+    "inside the Kaggle workspace – either by uploading the project as a dataset or by\n",
+    "linking a GitHub repository through Kaggle Notebooks.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0acef7c8",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 1. Environment setup\n",
+    "\n",
+    "Run the cell below to install project dependencies and register the `src/`\n",
+    "modules on the Python path. When executing inside Kaggle, this will install the\n",
+    "requirements into the session sandbox.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1714d542",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import subprocess\n",
+    "\n",
+    "PROJECT_ROOT = Path.cwd()\n",
+    "if not (PROJECT_ROOT / 'src').exists():\n",
+    "    PROJECT_ROOT = PROJECT_ROOT.parent\n",
+    "\n",
+    "REQUIREMENTS = PROJECT_ROOT / 'requirements.txt'\n",
+    "if REQUIREMENTS.exists():\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q', '-r', str(REQUIREMENTS)])\n",
+    "\n",
+    "if str(PROJECT_ROOT / 'src') not in sys.path:\n",
+    "    sys.path.append(str(PROJECT_ROOT / 'src'))\n",
+    "\n",
+    "print(f\"Project root: {PROJECT_ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65c9822c",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 2. Configure data and output directories\n",
+    "\n",
+    "Update the variables in the next cell to point at your dataset (typically\n",
+    "mounted beneath `/kaggle/input`) and to define where training artifacts should\n",
+    "be written (commonly `/kaggle/working/results`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efff0d60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Path to the feature matrix. Replace the placeholder with your dataset name.\n",
+    "# Example: Path('/kaggle/input/vpcf-dataset/x.npy')\n",
+    "data_path = Path('/kaggle/input/YOUR_DATASET_NAME/x.npy')\n",
+    "\n",
+    "# Optional: provide the path to ground-truth labels if available.\n",
+    "# Example: Path('/kaggle/input/vpcf-dataset/y.npy')\n",
+    "labels_path = None  # set to Path('...') when labels are present.\n",
+    "\n",
+    "# Where to store model checkpoints and logs.\n",
+    "results_root = Path('/kaggle/working/results')\n",
+    "results_root.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "print('Feature matrix:', data_path)\n",
+    "print('Labels path   :', labels_path)\n",
+    "print('Results folder:', results_root)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d603adb7",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 3. Load the dataset\n",
+    "\n",
+    "The cell below loads the feature matrix and (optionally) label array. Adjust the\n",
+    "`astype` target if you require a different dtype.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42caf363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "if not data_path.exists():\n",
+    "    raise FileNotFoundError(f'Update data_path to match your Kaggle dataset. {data_path} not found.')\n",
+    "\n",
+    "x = np.load(data_path).astype('float32')\n",
+    "print('Loaded features with shape:', x.shape)\n",
+    "\n",
+    "if labels_path is not None:\n",
+    "    if not labels_path.exists():\n",
+    "        raise FileNotFoundError(f'Labels path {labels_path} does not exist.')\n",
+    "    y = np.load(labels_path)\n",
+    "    print('Loaded labels with shape:', y.shape)\n",
+    "else:\n",
+    "    y = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c52f496",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 4. Train DEC\n",
+    "\n",
+    "This block performs autoencoder pretraining followed by DEC clustering. Adjust\n",
+    "the hyperparameters (e.g., `dims`, `n_clusters`, `maxiter`) to suit your data.\n",
+    "Results and logs are saved beneath the configured `results_root`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8944db42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from DEC import DEC\n",
+    "\n",
+    "dims = [x.shape[1], 500, 500, 2000, 10]\n",
+    "dec_save_dir = results_root / 'dec'\n",
+    "dec = DEC(dims=dims, n_clusters=10, save_dir=str(dec_save_dir))\n",
+    "\n",
+    "dec.pretrain(x, epochs=50, batch_size=256)\n",
+    "dec.compile(optimizer='sgd')\n",
+    "dec_labels = dec.fit(x, y=y, maxiter=8000, update_interval=200, batch_size=256)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbf5ce66",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 5. Train IDEC\n",
+    "\n",
+    "The IDEC workflow reuses the autoencoder weights (if available) and optimizes an\n",
+    "augmented objective. Reduce the epochs or `maxiter` values if you are exploring\n",
+    "interactively.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ebb4e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from IDEC import IDEC\n",
+    "\n",
+    "dims = [x.shape[1], 500, 500, 2000, 10]\n",
+    "idec_save_dir = results_root / 'idec'\n",
+    "idec = IDEC(dims=dims, n_clusters=10, save_dir=str(idec_save_dir))\n",
+    "\n",
+    "if not idec.pretrained:\n",
+    "    idec.pretrain(x, epochs=50, batch_size=256)\n",
+    "\n",
+    "idec.compile(optimizer='sgd')\n",
+    "idec_labels = idec.fit(x, y=y, maxiter=8000, update_interval=200, batch_size=256)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cce3d293",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 6. Run DBSCAN baseline\n",
+    "\n",
+    "DBSCAN offers a non-parametric baseline that can highlight structure without\n",
+    "requiring neural network training. Tune `eps` and `min_samples` for your data.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b20d49a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from DBSCANModel import DBSCANClustering\n",
+    "\n",
+    "# Hyperparameters are sensitive to feature scaling; adjust as necessary.\n",
+    "dbscan = DBSCANClustering(eps=0.5, min_samples=5, scale=True)\n",
+    "\n",
+    "dbscan_labels = dbscan.fit(x)\n",
+    "print('Unique cluster labels (including noise = -1):', sorted(set(dbscan_labels.tolist())))\n",
+    "\n",
+    "if y is not None:\n",
+    "    metrics = dbscan.evaluate(y)\n",
+    "    print('DBSCAN metrics (noise excluded):', metrics)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "399bec80",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## 7. Inspect generated artifacts\n",
+    "\n",
+    "Use the helper below to list the files that were produced during training. The\n",
+    "paths correspond to Kaggle's working directory, so you can add selected outputs\n",
+    "(e.g., final weights or CSV logs) to the notebook results section for download.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1234d2a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for folder in ['dec', 'idec']:\n",
+    "    target = results_root / folder\n",
+    "    if not target.exists():\n",
+    "        continue\n",
+    "    print(f'\n",
+    "Artifacts for {folder.upper()}:')\n",
+    "    for path in sorted(target.glob('**/*')):\n",
+    "        if path.is_file():\n",
+    "            size_kb = path.stat().st_size / 1024\n",
+    "            print(f'  {path.relative_to(results_root)} ({size_kb:.1f} KB)')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/DBSCANModel.py
+++ b/src/DBSCANModel.py
@@ -1,0 +1,125 @@
+"""DBSCAN clustering utilities for the project."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+from sklearn.preprocessing import StandardScaler
+
+import metrics
+
+
+@dataclass
+class DBSCANClustering:
+    """Convenience wrapper around :class:`sklearn.cluster.DBSCAN`.
+
+    Parameters
+    ----------
+    eps: float, default=0.5
+        The maximum distance between two samples for one to be considered as in the
+        neighborhood of the other. Passed directly to ``DBSCAN``.
+    min_samples: int, default=5
+        The number of samples in a neighborhood for a point to be considered as a
+        core point. Passed directly to ``DBSCAN``.
+    metric: str, default="euclidean"
+        Metric used by ``DBSCAN``.
+    scale: bool, default=True
+        Whether to apply :class:`~sklearn.preprocessing.StandardScaler` before
+        clustering. Scaling often improves DBSCAN performance on datasets with
+        heterogeneous feature scales.
+    treat_noise_as_cluster: bool, default=False
+        Whether to convert all noise points (label ``-1``) to their own dedicated
+        cluster when returning labels. The evaluation step always ignores noise, so
+        this option is mainly useful for downstream analysis that requires a label
+        for every sample.
+    """
+
+    eps: float = 0.5
+    min_samples: int = 5
+    metric: str = "euclidean"
+    scale: bool = True
+    treat_noise_as_cluster: bool = False
+
+    def __post_init__(self) -> None:
+        self._estimator: Optional[DBSCAN] = None
+        self._scaler: Optional[StandardScaler] = None
+        self.labels_: Optional[np.ndarray] = None
+
+    def fit(self, x: np.ndarray) -> np.ndarray:
+        """Cluster the provided dataset.
+
+        Parameters
+        ----------
+        x: numpy.ndarray
+            Feature matrix with shape ``(n_samples, n_features)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            Cluster labels for each sample. Noise points are marked with ``-1``
+            unless ``treat_noise_as_cluster`` is set to ``True``.
+        """
+
+        if x.ndim != 2:
+            raise ValueError("DBSCANClustering expects a 2D array as input.")
+
+        processed = x
+        if self.scale:
+            self._scaler = StandardScaler(with_mean=True, with_std=True)
+            processed = self._scaler.fit_transform(x)
+
+        self._estimator = DBSCAN(eps=self.eps, min_samples=self.min_samples, metric=self.metric)
+        raw_labels = self._estimator.fit_predict(processed)
+        self.labels_ = self._handle_noise(raw_labels)
+        return self.labels_
+
+    def _handle_noise(self, labels: np.ndarray) -> np.ndarray:
+        if not self.treat_noise_as_cluster:
+            return labels
+        if labels.size == 0:
+            return labels
+        result = labels.copy()
+        if np.any(result == -1):
+            non_noise = result[result != -1]
+            offset = non_noise.max(initial=-1) + 1
+            result[result == -1] = offset
+        return result
+
+    def evaluate(self, y_true: np.ndarray) -> Dict[str, float]:
+        """Compute clustering metrics on the fitted labels.
+
+        Noise points (labelled ``-1``) are excluded from the comparison because
+        most clustering metrics expect finite cluster ids.
+        """
+
+        if self.labels_ is None:
+            raise RuntimeError("Call `fit` before requesting evaluation metrics.")
+        if y_true.shape[0] != self.labels_.shape[0]:
+            raise ValueError("Ground truth labels must align with fitted predictions.")
+
+        mask = self.labels_ != -1
+        if not np.any(mask):
+            raise ValueError("All samples were marked as noise; cannot compute metrics.")
+
+        filtered_true = y_true[mask]
+        filtered_pred = self.labels_[mask]
+        return {
+            "acc": float(metrics.acc(filtered_true, filtered_pred)),
+            "nmi": float(metrics.nmi(filtered_true, filtered_pred)),
+            "ari": float(metrics.ari(filtered_true, filtered_pred)),
+        }
+
+    def get_estimator(self) -> DBSCAN:
+        if self._estimator is None:
+            raise RuntimeError("Call `fit` before requesting the underlying estimator.")
+        return self._estimator
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        """Project new samples using the scaling learnt during training."""
+        if not self.scale:
+            return x
+        if self._scaler is None:
+            raise RuntimeError("Call `fit` before requesting scaled features.")
+        return self._scaler.transform(x)

--- a/src/DEC.py
+++ b/src/DEC.py
@@ -129,8 +129,9 @@ class DEC(object):
         t0 = time()
         self.autoencoder.fit(x, x, batch_size=batch_size, epochs=epochs)
         print('Pretraining time: ', time() - t0)
-        self.autoencoder.save_weights(os.path.join(self.save_dir, 'ae_weights.weights.h5'))
-        print('Pretrained weights are saved to %s/ae_weights.h5' % self.save_dir)
+        weights_path = os.path.join(self.save_dir, 'ae_weights.weights.h5')
+        self.autoencoder.save_weights(weights_path)
+        print('Pretrained weights are saved to %s' % weights_path)
         self.pretrained = True
 
     def load_weights(self, weights_path): # load weights of DEC model
@@ -214,14 +215,16 @@ class DEC(object):
             # save intermediate model
             if ite % save_interval == 0:
                 # save DEC model checkpoints
-                print('saving model to:', os.path.join(self.save_dir, 'DEC_model_' + str(ite) + '.h5'))
-                self.model.save_weights(os.path.join(self.save_dir, 'DEC_model_' + str(ite) + '.h5'))
+                checkpoint_path = os.path.join(self.save_dir, f'DEC_model_{ite}.weights.h5')
+                print('saving model to:', checkpoint_path)
+                self.model.save_weights(checkpoint_path)
 
             ite += 1
 
         # save the trained model
         logfile.close()
-        print('saving model to:', os.path.join(self.save_dir, 'DEC_model_final.h5'))
-        self.model.save_weights(os.path.join(self.save_dir, 'DEC_model_final.weights.h5'))
+        final_path = os.path.join(self.save_dir, 'DEC_model_final.weights.h5')
+        print('saving model to:', final_path)
+        self.model.save_weights(final_path)
 
         return y_pred


### PR DESCRIPTION
## Summary
- add a DBSCAN clustering utility alongside DEC/IDEC for baseline comparisons
- create a Kaggle-ready training notebook and detailed text walkthrough for remote execution
- document the new resources in the README for easier discovery